### PR TITLE
Change SWM logo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,6 @@ config :ibm_speech_to_text, api_key: "YOUR_API_KEY_HERE"
 
 Copyright 2019, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=membrane-element-ibm-speech-to-text)
 
-[![Software Mansion](https://membraneframework.github.io/static/logo/swm_logo_readme.png)](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=membrane-element-ibm-speech-to-text)
+[![Software Mansion](https://logo.swmansion.com/logo?color=white&variant=desktop&width=200&tag=membrane-github)](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=membrane-element-ibm-speech-to-text)
 ipeline
 Licensed under the [Apache License, Version 2.0](LICENSE)


### PR DESCRIPTION
<sup>proudly automated with <a href="https://github.com/membraneframework/sebex">Sebex</a></sup>